### PR TITLE
Fix preview instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ The website uses Jekyll powered Github pages.
 
 To preview locally use docker:
 ```
-docker run --rm --volume=$(pwd):/srv/jekyll -i -t -p 127.0.0.1:4000:4000 jekyll/jekyll:pages
+docker run --rm --volume=$(pwd):/srv/jekyll -i -t -p 127.0.0.1:4000:4000 jekyll/jekyll:pages jekyll serve
 ```
 The website can be viewed on http://localhost:4000


### PR DESCRIPTION
The preview command does not work for me:

```
$ docker run --rm --volume=$(pwd):/srv/jekyll -i -t -p 127.0.0.1:4000:4000 jekyll/jekyll:pages
Unable to find image 'jekyll/jekyll:pages' locally
pages: Pulling from jekyll/jekyll
fa6e0f3cab49: Pull complete 
f212a8fb2699: Pull complete 
Digest: sha256:13e0f64d7112a513f481731c472b2dcac4eecf4c8a9536046e5aae2141894bfb
Status: Downloaded newer image for jekyll/jekyll:pages
jekyll 3.5.1 -- Jekyll is a blog-aware, static site generator in Ruby

Usage:

  jekyll <subcommand> [options]

Options:
        -s, --source [DIR]  Source directory (defaults to ./)
        -d, --destination [DIR]  Destination directory (defaults to ./_site)
            --safe         Safe mode (defaults to false)
        -p, --plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]  Plugins directory (defaults to ./_plugins)
            --layouts DIR  Layouts directory (defaults to ./_layouts)
            --profile      Generate a Liquid rendering profile
        -h, --help         Show this message
        -v, --version      Print the name and version
        -t, --trace        Show the full backtrace when an error occurs

Subcommands:
  docs                  
  import                
  build, b              Build your site
  clean                 Clean the site (removes site output and metadata file) without building.
  doctor, hyde          Search site and print specific deprecation warnings
  help                  Show the help message, optionally for a given subcommand.
  new                   Creates a new Jekyll site scaffold in PATH
  new-theme             Creates a new Jekyll theme scaffold
  serve, server, s      Serve your site locally

```
After telling Docker to run `jekyll serve` it does work, not sure if that's the correct solution though.