### PR TITLE
added citationcff organization to list of NLeSC organizations

### DIFF
--- a/_organizations/citationcff.md
+++ b/_organizations/citationcff.md
@@ -1,0 +1,7 @@
+---
+title: citationcff
+homepage: https://github.com/citationcff
+avatar: https://avatars1.githubusercontent.com/u/35332521?v=4
+---
+
+    


### PR DESCRIPTION
I'm assuming I should add this org as well then.