### PR TITLE
citationcff is now part of the official CFF repo

### DIFF
--- a/_organizations/citation-file-format.md
+++ b/_organizations/citation-file-format.md
@@ -1,0 +1,7 @@
+---
+title: citation-file-format
+homepage: https://github.com/citation-file-format
+avatar: https://avatars2.githubusercontent.com/u/32704278?v=4
+---
+
+    

--- a/_organizations/citationcff.md
+++ b/_organizations/citationcff.md
@@ -1,7 +1,0 @@
----
-title: citationcff
-homepage: https://github.com/citationcff
-avatar: https://avatars1.githubusercontent.com/u/35332521?v=4
----
-
-    


### PR DESCRIPTION
moved from https://github.com/citationcff/citationcff to https://github.com/citation-file-format/citationcff