### PR TITLE
Using bootstrap to fix the issue "Long descriptions mess up layout"

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,7 @@
 <footer class="site-footer">
 
-  <div class="wrapper">
+  <!-- Used .container class insted of wrapper -->
+  <div class="container">
 
 
     <div class="footer-col-wrapper">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,9 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
+  <!-- Bootstrap css -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
+
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,7 @@
 <header class="site-header">
 
-  <div class="wrapper">
+  <!-- Used .container class insted of wrapper -->
+  <div class="container">
 
     <a class="site-title" href="http://estep.esciencecenter.nl/">{{ site.title }}</a>
     <!--a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a-->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,8 @@
     {% include header.html %}
 
     <div class="page-content">
-      <div class="wrapper">
+      <!-- Used .container class insted of wrapper -->
+      <div class="container">
         {{ content }}
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -7,21 +7,27 @@ layout: default
 <p>
 Github organizations of <a href="https://www.esciencecenter.nl/projects">Netherlands eScience center projects</a>.
 </p>
-
-<div class="organizations">
+<!-- Use the .card-deck class creates a grid of cards that are of equal height and width. The layout will automatically adjust as you insert more cards, displayed vertically on small screens (less than 576px): -->
+<div class="card-deck">
     {% for organization in site.organizations %}
-    <div class="organization">
-        <a href="{{ organization.homepage }}">
-            <table><tr><td>
-                <img class="avatar" src="{{ organization.avatar }}"/>
-            </td><td>
-                <h2>{{ organization.title }}</h2>
-            </td></tr></table>
-            <p>
+    <!-- A card in Bootstrap 4 is a bordered box with some padding around its content. It includes options for headers, footers, content, colors, etc. -->
+        <div class="card text-center" style="min-width: 25%; margin-bottom: 1em !important;">
+          <div class="card-header">
+            <a href="{{ organization.homepage }}">
+                <h5 class="card-title">{{ organization.title }}</h5>
+            </a>
+          </div>
+          <div class="card-body">
+            <a href="{{ organization.homepage }}">
+                <!-- use the .rounded class to class adds rounded corners to an image and use .float-left to float the avatar img to the left side -->
+                <img class="avatar rounded float-left" src="{{ organization.avatar }}"/>
+            </a>
+            <p class="card-text">
                 {{ organization.content }}
             </p>
-        </a>
-    </div>
+          </div>
+          
+          </div> 
     {% endfor %}
 </div>
 


### PR DESCRIPTION
Just using the bootstrap class creates a grid of cards that are of equal height and width.
The layout will automatically adjust as you insert more cards, displayed vertically on small screens (less than 576px).