### PR TITLE
Add disaster capitalism project to NLeSC projects website

### DIFF
--- a/_organizations/disaster-capitalism.md
+++ b/_organizations/disaster-capitalism.md
@@ -1,0 +1,7 @@
+---
+title: Resilient Markets or "Disaster Capitalism"?
+homepage: https://github.com/disaster-capitalism
+avatar: https://avatars.githubusercontent.com/u/103410835?s=400&v=4
+---
+
+Combining critical discourse analysis and machine learning to analyze the OECD's policies in the corpus "Studies on Water".


### PR DESCRIPTION
Adds the "Resilient Markets or 'Disaster Capitalism'" project.