### PR TITLE
Delete WhatWorksWhenForWhom.md

### DIFF
--- a/_organizations/WhatWorksWhenForWhom.md
+++ b/_organizations/WhatWorksWhenForWhom.md
@@ -1,6 +1,0 @@
----
-title: WhatWorksWhenForWhom
-homepage: https://github.com/WhatWorksWhenForWhom
-avatar: https://avatars3.githubusercontent.com/u/20316820?v=3
----
-Github organization for the What Works When for Whom? project.


### PR DESCRIPTION
This points to an empty organization, with 1 empty repo.
The project is also duplicated as 'WhatWorksWhenForWhom?"

Please delete this org.